### PR TITLE
Fix compatibility issues with kadence blocks and woocommerce HPOS

### DIFF
--- a/classes/WooCommerce.php
+++ b/classes/WooCommerce.php
@@ -88,10 +88,9 @@ class WooCommerce {
                 let $product      = $('div.woocommerce-product-gallery');
                 let sold_out_text = "<?php echo Badge::get_text() ?>";
                 $form.on('show_variation', function (event, data) {
+                    $('.wcsob_soldout').remove();
                     if (!data.is_in_stock) {
                         $product.prepend('<span class="wcsob_soldout">' + sold_out_text + '</span>');
-                    } else {
-                        $('.wcsob_soldout').remove();
                     }
                 });
                 $form.on('reset_data', function () {

--- a/classes/WooCommerce.php
+++ b/classes/WooCommerce.php
@@ -85,7 +85,7 @@ class WooCommerce {
 		<script type="text/javascript">
             (function ($) {
                 let $form         = $('form.variations_form');
-                let $product      = $form.closest('.product');
+                let $product      = $('div.woocommerce-product-gallery');
                 let sold_out_text = "<?php echo Badge::get_text() ?>";
                 $form.on('show_variation', function (event, data) {
                     if (!data.is_in_stock) {

--- a/sold-out-badge-for-woocommerce.php
+++ b/sold-out-badge-for-woocommerce.php
@@ -76,3 +76,9 @@ class WCSOB {
 }
 
 WCSOB::get_instance()->init();
+
+add_action( 'before_woocommerce_init', function() {
+        if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+                \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+        }
+} );


### PR DESCRIPTION
The first two fixes I am unsure of
- the first provides a solution that works well on my end to ensure badges are displayed properly in "native" woocommerce product loop/etc and as well, with kadence block (based on gutemberg, simply tagetting the product gallery)
- the second i am more certain is simply to avoid having several badge elements piling up under whatever element plugin managed to find (this is not visible since they are positioned, but it shows in the DOM)
- the last is to get rid of the annoying HPOS warning in woocommerce; i am reasonably sure this plugin is compatible with the DB schema changes but this has to be declared explicitly